### PR TITLE
build: write protoc dependency output into OUT_DIR

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 use std::process::Command;
-use std::process::Stdio;
 
 use std::env;
 use std::path::PathBuf;
@@ -57,6 +56,8 @@ pub fn protoc_bin_path() -> Result<PathBuf, Error> {
 fn main() {
     // The proto files defining the message types we want to support.
     let roots = ["protos/perfetto/trace/trace.proto"];
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR must be set by cargo"));
+    let depfile_path = out_dir.join("perfetto_protos.deps");
     let protoc = match protoc_bin_path() {
         Ok(path) => match path.to_str() {
             Some(s) => s.to_owned(),
@@ -75,16 +76,16 @@ fn main() {
     };
 
     // Find the transitive deps of `roots`.
+    let dependency_out_arg = format!("--dependency_out={}", depfile_path.display());
     let child = Command::new(protoc.clone())
-        .arg("--dependency_out=/dev/stdout")
+        .arg(dependency_out_arg)
         .arg("--descriptor_set_out=/dev/null")
         .args(roots)
-        .stdout(Stdio::piped())
         .spawn()
         .unwrap();
     let result = child.wait_with_output().unwrap();
     assert!(result.status.success());
-    let output = core::str::from_utf8(&result.stdout).unwrap();
+    let output = std::fs::read_to_string(&depfile_path).unwrap();
     let output = output.replace("\\\n", " ");
     let output = output.replace("/dev/null: ", "");
     let files: Vec<&str> = output.split_ascii_whitespace().collect();


### PR DESCRIPTION
# Problem
`build.rs` currently asks `protoc` to write dependency output to `/dev/stdout` and then parses child stdout. In sandboxed environments that deny writes to device paths, this fails with `/dev/stdout: Operation not permitted`, which blocks building crates that depend on `perfetto_protos`.

# Mental model
This build step has two phases: discover the transitive `.proto` input set, then run Rust protobuf codegen over that set. The transport used for dependency output is an implementation detail; using a regular file under `OUT_DIR` preserves the same dependency data while removing reliance on special device paths.

# Non-goals
- No schema or generated API changes.
- No change to vendored `protoc` binaries or platform selection logic.
- No behavior change in protobuf code generation.

# Tradeoffs
- Adds one small depfile in `OUT_DIR` during build.
- Avoids `/dev/stdout` path semantics that vary across sandbox policies.
- Keeps the same parser and normalization flow for dependency lines.

# Architecture
The patch changes only the dependency-output transport in `build.rs`:
1. Build a depfile path at `$OUT_DIR/perfetto_protos.deps`.
2. Invoke `protoc` with `--dependency_out=<that path>` (instead of `/dev/stdout`).
3. Read the depfile content from disk.
4. Apply the same normalization (`\\\n` folding and `/dev/null: ` stripping) and pass the same file list into `protobuf_codegen::Codegen`.

# Observability
Before this change, failures surface as an immediate build-script error from `protoc` when opening `/dev/stdout` as a path. After this change, the critical failure points are:
- `protoc` exit status (still asserted), and
- depfile readability in `OUT_DIR`.

When debugging, inspect build-script stderr plus the depfile under `OUT_DIR` for malformed dependency output.

# Tests
Validated with downstream consumers that exercise this crate in real build pipelines:
1. Local sandboxed build path that previously failed on `/dev/stdout` now succeeds.
2. `cargo check -p chili --all-targets` succeeds with this revision pinned.
3. `cargo run --bin dump_struct -- --chip-version JalapenoA0` succeeds.
4. `cargo run --bin dump_enum_json -- --chip-version JalapenoA0` succeeds.
5. Remote `bazel build -k //oai_internal/chili:chili` on `devbox-ubuntu2404` succeeds.
